### PR TITLE
Refactor to sync pipeline, retire simple_q2_to_cxi.py (v0.2.0)

### DIFF
--- a/cxi_pipeline_ray/cli.py
+++ b/cxi_pipeline_ray/cli.py
@@ -13,7 +13,8 @@ import ray
 
 from .utils.config import load_config, merge_config_with_overrides
 from .utils.validation import print_validation_result
-from .core.coordinator import run_cpu_postprocessing_pipeline
+from .core.coordinator import run_sync_pipeline
+from .core.file_writer import CXIFileWriterActor
 from .version import __version__
 
 
@@ -72,7 +73,7 @@ def main():
     2. Validation mode: Validate config consistency
     """
     parser = argparse.ArgumentParser(
-        description="CXI Pipeline Writer - Ray-based CPU post-processing for PeakNet inference",
+        description="CXI Pipeline Writer - Synchronous post-processing for PeakNet inference",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -80,7 +81,7 @@ Examples:
   cxi-writer --config cxi_writer.yaml
 
   # With CLI overrides
-  cxi-writer --config cxi_writer.yaml --num-cpu-workers 32 --output-dir /custom/path
+  cxi-writer --config cxi_writer.yaml --batches-per-file 20 --output-dir /custom/path
 
   # Validate config consistency
   cxi-writer --validate-config --pipeline-config pipeline.yaml --writer-config writer.yaml
@@ -116,15 +117,15 @@ Examples:
 
     # CLI overrides
     parser.add_argument(
-        '--num-cpu-workers',
+        '--batches-per-file',
         type=int,
-        help='Override number of CPU workers'
+        help='Write CXI file every N batches (default: 10)'
     )
 
     parser.add_argument(
-        '--max-pending-tasks',
-        type=int,
-        help='Override max pending tasks (backpressure limit)'
+        '--save-segmentation-maps',
+        action='store_true',
+        help='Save segmentation maps to /entry_1/result_1/segmentation_map (debug mode)'
     )
 
     parser.add_argument(
@@ -186,7 +187,7 @@ Examples:
     logger.info(f"Ray namespace: {config['ray']['namespace']}")
     logger.info(f"Queue: {config['queue']['name']} ({config['queue']['num_shards']} shards)")
     logger.info(f"Output dir: {config['output']['output_dir']}")
-    logger.info(f"CPU workers: {config['processing']['num_cpu_workers']}")
+    logger.info(f"Batches per file: {config['output']['batches_per_file']}")
 
     # Connect to Ray
     logger.info("Connecting to Ray cluster...")
@@ -220,19 +221,28 @@ Examples:
         logger.error(f"Failed to connect to Q2 queue: {e}")
         sys.exit(1)
 
+    # Create file writer actor
+    logger.info("Creating CXI file writer actor...")
+    geom_file = config.get('geometry', {}).get('geom_file')
+    file_writer = CXIFileWriterActor.remote(
+        output_dir=config['output']['output_dir'],
+        geom_file=geom_file,
+        buffer_size=config['output']['buffer_size'],
+        min_num_peak=config['peak_finding']['min_num_peak'],
+        max_num_peak=config['peak_finding']['max_num_peak'],
+        file_prefix=config['output']['file_prefix'],
+        crystfel_mode=geom_file is not None,
+        save_segmentation_maps=config['output'].get('save_segmentation_maps', False),
+    )
+
     # Run pipeline
-    logger.info("Starting CPU post-processing pipeline...")
+    logger.info("Starting synchronous post-processing pipeline...")
     try:
-        run_cpu_postprocessing_pipeline(
+        run_sync_pipeline(
             q2_manager=q2_manager,
-            output_dir=config['output']['output_dir'],
-            geom_file=config.get('geometry', {}).get('geom_file'),
-            num_cpu_workers=config['processing']['num_cpu_workers'],
-            buffer_size=config['output']['buffer_size'],
-            min_num_peak=config['peak_finding']['min_num_peak'],
-            max_num_peak=config['peak_finding']['max_num_peak'],
-            max_pending_tasks=config['processing']['max_pending_tasks'],
-            file_prefix=config['output']['file_prefix']
+            file_writer=file_writer,
+            batches_per_file=config['output']['batches_per_file'],
+            save_segmentation_maps=config['output'].get('save_segmentation_maps', False),
         )
     except KeyboardInterrupt:
         logger.info("Interrupted by user")

--- a/cxi_pipeline_ray/core/__init__.py
+++ b/cxi_pipeline_ray/core/__init__.py
@@ -1,11 +1,13 @@
 """Core components for CXI pipeline processing."""
 
-from .peak_finding import process_samples_task
+from .peak_finding import find_peaks_numpy
 from .file_writer import CXIFileWriterActor
-from .coordinator import run_cpu_postprocessing_pipeline
+from .coordinator import group_panels_into_events, run_sync_pipeline, process_batch
 
 __all__ = [
-    "process_samples_task",
+    "find_peaks_numpy",
     "CXIFileWriterActor",
-    "run_cpu_postprocessing_pipeline",
+    "group_panels_into_events",
+    "run_sync_pipeline",
+    "process_batch",
 ]

--- a/cxi_pipeline_ray/core/coordinator.py
+++ b/cxi_pipeline_ray/core/coordinator.py
@@ -1,28 +1,16 @@
 """
-Main pipeline coordinator with Ray best practices.
+Synchronous pipeline coordinator for CXI post-processing.
 
-This module implements the optimized CPU post-processing pipeline that:
-- Pulls batches from Q2
-- Splits into mini-batches for parallel processing
-- Launches Ray tasks with backpressure control
-- Submits results to file writer actor
-
-Key optimizations:
-- Batched ray.get() calls (no loops) - +20-30% throughput
-- ObjectRefs for large objects - -90% memory usage
-- Backpressure control - Prevents OOM
-- Pipelining pattern - +10-15% throughput
-- Efficient ray.wait() usage
+Pulls batches from Q2, runs peak finding, groups panels into events,
+and submits results to the CXI file writer actor.
 """
 
 import logging
-import time
-import ray
 import numpy as np
+import ray
 
-from .peak_finding import process_samples_task
-from .file_writer import CXIFileWriterActor
-from .reconstruction import reconstruct_detector_image, wavelength_to_energy
+from .peak_finding import find_peaks_numpy
+from .reconstruction import reconstruct_from_arrays, wavelength_to_energy
 
 
 def group_panels_into_events(batch_info):
@@ -130,369 +118,195 @@ def group_panels_into_events(batch_info):
     return event_images, event_peaks, event_metadata, event_seg_maps
 
 
-def run_cpu_postprocessing_pipeline(
-    q2_manager,
-    output_dir: str,
-    geom_file: str,
-    num_cpu_workers: int = 16,
-    buffer_size: int = 100,
-    min_num_peak: int = 10,
-    max_num_peak: int = 2048,
-    max_pending_tasks: int = 100,
-    file_prefix: str = "peaknet_cxi"
-):
+def process_batch(pipeline_output, file_writer, save_segmentation_maps: bool = False):
     """
-    Optimized CPU post-processing pipeline with Ray best practices.
+    Process a single batch from Q2 through peak finding and submit to writer.
 
-    Architecture:
-    - Pulls batches from Q2 (ShardedQueue)
-    - Splits into mini-batches for parallel processing
-    - Launches Ray tasks for peak finding (stateless)
-    - Submits results to file writer actor (stateful)
+    Args:
+        pipeline_output: PipelineOutput object from Q2
+        file_writer: CXIFileWriterActor instance
+        save_segmentation_maps: Save segmentation maps to CXI (debug mode)
+
+    Returns:
+        Number of events processed
+    """
+    # Extract logits
+    logits = pipeline_output.get_torch_tensor(device='cpu').numpy()  # (B*C, num_classes, H, W)
+
+    # Extract B, C, H_orig, W_orig from preprocessing metadata
+    B, C, H_orig, W_orig = None, None, None, None
+
+    if hasattr(pipeline_output, 'preprocessing_metadata') and pipeline_output.preprocessing_metadata is not None:
+        original_shape = pipeline_output.preprocessing_metadata.original_shape
+        B, C, H_orig, W_orig = original_shape
+        logging.debug(f"Extracted shape from metadata: B={B}, C={C}, H={H_orig}, W={W_orig}")
+    else:
+        logging.warning("NO preprocessing_metadata found! This may cause detector image/seg map mismatch!")
+
+    # Try to extract detector images (can fail independently)
+    detector_images_4d = None
+
+    if hasattr(pipeline_output, 'original_image_ref') and pipeline_output.original_image_ref is not None:
+        try:
+            if hasattr(pipeline_output, 'preprocessing_metadata') and pipeline_output.preprocessing_metadata is not None:
+                original_image = ray.get(pipeline_output.original_image_ref)
+                preprocessed_shape = pipeline_output.preprocessing_metadata.preprocessed_shape
+                detector_images_4d = reconstruct_from_arrays(original_image, original_shape, preprocessed_shape)
+                logging.debug(f"Reconstructed detector images: {detector_images_4d.shape}")
+            else:
+                original_image_raw = ray.get(pipeline_output.original_image_ref)
+                logging.warning(f"NO preprocessing metadata - using images as-is: {original_image_raw.shape}")
+                detector_images_4d = original_image_raw
+        except Exception as e:
+            logging.warning(f"Failed to extract detector images: {e}")
+            detector_images_4d = None
+    else:
+        logging.warning("NO original_image_ref found! Detector images will be None")
+
+    # Extract physics metadata
+    metadata = pipeline_output.metadata if hasattr(pipeline_output, 'metadata') else {}
+
+    # Handle photon wavelength → energy conversion
+    photon_wavelength = metadata.get('photon_wavelength', None)
+    photon_energy = metadata.get('photon_energy', None)
+
+    if photon_wavelength is not None:
+        if isinstance(photon_wavelength, (list, np.ndarray)):
+            photon_energy = np.array([wavelength_to_energy(w) for w in photon_wavelength])
+        else:
+            photon_energy = wavelength_to_energy(float(photon_wavelength))
+
+    timestamp = metadata.get('timestamp', None)
+
+    # Run peak finding on logits
+    logging.debug(f"Running peak finding on {logits.shape[0]} panels (logits shape: {logits.shape})...")
+    if B and C and logits.shape[0] != B * C:
+        logging.error(f"MISMATCH: logits.shape[0]={logits.shape[0]} but B*C={B*C}!")
+
+    all_peaks = []
+    all_seg_maps = [] if save_segmentation_maps else None
+
+    for panel_idx in range(logits.shape[0]):
+        panel_logits = logits[panel_idx]  # (2, H, W)
+
+        if save_segmentation_maps:
+            peaks, seg_map = find_peaks_numpy(panel_logits, return_seg_map=True)
+        else:
+            peaks = find_peaks_numpy(panel_logits)
+
+        # Clip peaks to original bounds
+        if H_orig and W_orig:
+            peaks_transformed = []
+            for peak in peaks:
+                _, y, x = peak
+                if y < H_orig and x < W_orig:
+                    peaks_transformed.append([0, y, x])
+            all_peaks.append(np.array(peaks_transformed) if peaks_transformed else np.array([]).reshape(0, 3))
+
+            if save_segmentation_maps:
+                all_seg_maps.append(seg_map[:H_orig, :W_orig])
+        else:
+            all_peaks.append(peaks)
+            if save_segmentation_maps:
+                all_seg_maps.append(seg_map)
+
+    # Group panels into events
+    completed_panels = []
+    for panel_idx in range(len(all_peaks)):
+        completed_panels.append((panel_idx, all_peaks[panel_idx], None))
+
+    batch_info = {
+        'completed_panels': completed_panels,
+        'B': B if B is not None else 1,
+        'C': C if C is not None else len(all_peaks),
+        'H_orig': H_orig,
+        'W_orig': W_orig,
+        'detector_images_4d': detector_images_4d,
+        'photon_energy': photon_energy,
+        'photon_wavelength': photon_wavelength,
+        'timestamp': timestamp,
+        'metadata': metadata,
+        'num_panels': len(all_peaks),
+        'segmentation_maps': all_seg_maps,
+    }
+
+    event_images, event_peaks, event_metadata, event_seg_maps = group_panels_into_events(batch_info)
+
+    # Submit to file writer
+    file_writer.submit_processed_batch.remote(event_images, event_peaks, event_metadata, event_seg_maps)
+
+    total_peaks = sum(len(p) for p in all_peaks)
+    logging.debug(f"Submitted {len(event_images)} events, {total_peaks} total peaks")
+
+    return len(event_images)
+
+
+def run_sync_pipeline(q2_manager, file_writer, batches_per_file: int = 10, save_segmentation_maps: bool = False):
+    """
+    Synchronous pipeline: pull from Q2, process, write CXI files.
 
     Args:
         q2_manager: ShardedQueueManager for Q2 output queue
-        output_dir: Directory for CXI files
-        geom_file: Geometry file for CheetahConverter (can be None to skip conversion)
-        num_cpu_workers: Number of parallel CPU tasks for peak finding
-        buffer_size: Events to buffer before writing CXI
-        min_num_peak: Minimum peaks to save event
-        max_num_peak: Maximum peaks per event
-        max_pending_tasks: Max pending tasks (backpressure limit)
-        file_prefix: Prefix for CXI filenames
-
-    Key improvements:
-    - Batched ray.get() calls (no loops) - +20-30% throughput
-    - ObjectRefs for large objects - -90% memory usage
-    - Backpressure control - Prevents OOM
-    - Pipelining pattern - +10-15% throughput
-    - Efficient ray.wait() usage
+        file_writer: CXIFileWriterActor instance (already created)
+        batches_per_file: Write CXI file every N batches
+        save_segmentation_maps: Save segmentation maps to CXI (debug mode)
     """
-    logging.info("=== Starting Optimized CPU Post-Processing Pipeline ===")
-    logging.info(f"CPU workers: {num_cpu_workers}")
-    logging.info(f"Max pending tasks: {max_pending_tasks}")
-    logging.info(f"Output dir: {output_dir}")
-    logging.info(f"Geometry file: {geom_file}")
+    logger = logging.getLogger(__name__)
+    logger.info("Starting synchronous pipeline loop...")
+    logger.info(f"Batches per file: {batches_per_file}")
+    logger.info(f"Save segmentation maps: {save_segmentation_maps}")
 
-    # Determine if CrystFEL mode based on geometry file
-    crystfel_mode = geom_file is not None and geom_file != ""
-
-    # Create file writer actor (stateful)
-    file_writer = CXIFileWriterActor.remote(
-        output_dir=output_dir,
-        geom_file=geom_file,
-        buffer_size=buffer_size,
-        min_num_peak=min_num_peak,
-        max_num_peak=max_num_peak,
-        file_prefix=file_prefix,
-        crystfel_mode=crystfel_mode
-    )
-
-    # Create shared structure for all tasks (8-connectivity)
-    structure = np.ones((3, 3), dtype=np.float32)
-    structure_ref = ray.put(structure)  # Put once, share everywhere
-
-    # Track in-flight tasks
-    pending_tasks = []
-    batch_tracker = {}  # Track batch-level information for event grouping
-    batch_id_counter = 0
-    batches_processed = 0
-    start_time = time.time()
-
-    logging.info("Starting main consumption loop...")
-
-    # OPTIMIZATION: Pipelining - prefetch first batch
-    current_batch = q2_manager.get(timeout=0.01)
+    batch_count = 0
+    total_events = 0
+    batches_since_flush = 0
 
     try:
         while True:
-            # RAY BEST PRACTICE: Backpressure control - wait if too many pending
-            if len(pending_tasks) >= max_pending_tasks:
-                logging.debug(f"Backpressure: {len(pending_tasks)} pending, waiting...")
+            # Pull batch from Q2 (blocking with short timeout)
+            pipeline_output = q2_manager.get(timeout=0.1)
 
-                # Block until at least one completes
-                ready_refs = [t['task_ref'] for t in pending_tasks]
-                ready, not_ready_refs = ray.wait(
-                    ready_refs,
-                    num_returns=1,  # Wait for at least 1
-                    timeout=None  # Blocking
-                )
-
-                # RAY BEST PRACTICE: Batch ray.get() - fetch all at once
-                ready_peaks = ray.get(ready)
-                ready_task_map = {ref: peaks for ref, peaks in zip(ready, ready_peaks)}
-
-                # Collect completed panel results
-                completed_batches = set()
-                for task_ref in ready:
-                    task_data = next(t for t in pending_tasks if t['task_ref'] == task_ref)
-                    batch_id = task_data['batch_id']
-                    panel_start_idx = task_data['panel_start_idx']
-                    panel_count = task_data['panel_count']
-                    peaks_list = ready_task_map[task_ref]
-
-                    # Store peaks for each panel in this mini-batch
-                    batch_info = batch_tracker[batch_id]
-                    for i in range(panel_count):
-                        panel_idx = panel_start_idx + i
-                        panel_peaks = peaks_list[i] if i < len(peaks_list) else []
-                        batch_info['completed_panels'].append((panel_idx, panel_peaks, None))
-
-                    # Check if this batch is complete
-                    if len(batch_info['completed_panels']) >= batch_info['num_panels']:
-                        completed_batches.add(batch_id)
-
-                # Update pending list
-                pending_tasks = [t for t in pending_tasks if t['task_ref'] not in ready]
-
-                # Submit completed batches
-                for batch_id in completed_batches:
-                    batch_info = batch_tracker[batch_id]
-                    event_images, event_peaks, event_metadata = group_panels_into_events(batch_info)
-                    file_writer.submit_processed_batch.remote(event_images, event_peaks, event_metadata)
-                    del batch_tracker[batch_id]
-
-            # Check if we have a batch to process
-            if current_batch is None:
-                # OPTIMIZATION: Pipelining - prefetch next batch
-                current_batch = q2_manager.get(timeout=0.01)
-
-                # Check pending tasks while waiting
-                if pending_tasks:
-                    ready_refs = [t['task_ref'] for t in pending_tasks]
-                    ready, not_ready_refs = ray.wait(
-                        ready_refs,
-                        num_returns=min(10, len(ready_refs)),  # Optimized num_returns
-                        timeout=0  # Non-blocking
-                    )
-
-                    if ready:
-                        # Batch ray.get()
-                        ready_peaks = ray.get(ready)
-                        ready_task_map = {ref: peaks for ref, peaks in zip(ready, ready_peaks)}
-
-                        # Collect completed panel results
-                        completed_batches = set()
-                        for task_ref in ready:
-                            task_data = next(t for t in pending_tasks if t['task_ref'] == task_ref)
-                            batch_id = task_data['batch_id']
-                            panel_start_idx = task_data['panel_start_idx']
-                            panel_count = task_data['panel_count']
-                            peaks_list = ready_task_map[task_ref]
-
-                            # Store peaks for each panel in this mini-batch
-                            batch_info = batch_tracker[batch_id]
-                            for i in range(panel_count):
-                                panel_idx = panel_start_idx + i
-                                panel_peaks = peaks_list[i] if i < len(peaks_list) else []
-                                batch_info['completed_panels'].append((panel_idx, panel_peaks, None))
-
-                            # Check if this batch is complete
-                            if len(batch_info['completed_panels']) >= batch_info['num_panels']:
-                                completed_batches.add(batch_id)
-
-                        pending_tasks = [t for t in pending_tasks if t['task_ref'] not in ready]
-
-                        # Submit completed batches
-                        for batch_id in completed_batches:
-                            batch_info = batch_tracker[batch_id]
-                            event_images, event_peaks, event_metadata = group_panels_into_events(batch_info)
-                            file_writer.submit_processed_batch.remote(event_images, event_peaks, event_metadata)
-                            del batch_tracker[batch_id]
-
+            if pipeline_output is None:
                 continue
 
-            # Extract data from current PipelineOutput
-            logits = current_batch.get_torch_tensor(device='cpu')  # (B*C, num_classes, H, W)
+            # Process batch
+            num_events = process_batch(
+                pipeline_output,
+                file_writer,
+                save_segmentation_maps=save_segmentation_maps,
+            )
+            batch_count += 1
+            total_events += num_events
+            batches_since_flush += 1
 
-            # NEW: Extract and reconstruct detector images for CXI file writing
-            detector_images_4d = None
-            B, C, H_orig, W_orig = None, None, None, None
-            if hasattr(current_batch, 'original_image_ref') and current_batch.original_image_ref is not None:
-                try:
-                    if hasattr(current_batch, 'preprocessing_metadata') and current_batch.preprocessing_metadata is not None:
-                        # Reconstruct to original size: (B*C,1,H,W) → (B,C,H_orig,W_orig)
-                        detector_images_4d = reconstruct_detector_image(current_batch)
-                        # Keep as 4D for event structure - don't flatten!
-                        B, C, H_orig, W_orig = detector_images_4d.shape
-                        logging.debug(f"Reconstructed detector images: {detector_images_4d.shape}")
-                    else:
-                        # No preprocessing metadata - use as-is
-                        detector_images_4d = ray.get(current_batch.original_image_ref)
-                        logging.debug(f"Using detector images as-is: {detector_images_4d.shape}")
-                except Exception as e:
-                    logging.warning(f"Failed to extract detector images: {e}, will use logits as fallback")
-                    detector_images_4d = None
+            logger.info(f"Processed batch {batch_count}: {num_events} events (total: {total_events})")
 
-            # NEW: Extract physics metadata and convert to CXI format
-            metadata = current_batch.metadata if hasattr(current_batch, 'metadata') else {}
-
-            # Handle photon wavelength → energy conversion (event-level)
-            photon_wavelength = metadata.get('photon_wavelength', None)
-            photon_energy = metadata.get('photon_energy', None)
-
-            if photon_wavelength is not None:
-                # Convert wavelength to energy
-                if isinstance(photon_wavelength, (list, np.ndarray)):
-                    photon_energy = wavelength_to_energy(np.array(photon_wavelength), unit='angstrom')
-                else:
-                    photon_energy = wavelength_to_energy(float(photon_wavelength), unit='angstrom')
-
-            # Extract timestamp (event-level)
-            timestamp = metadata.get('timestamp', None)
-
-            # Store batch-level metadata for later event grouping
-            batch_size = logits.size(0)  # B*C panels
-            batch_id = batch_id_counter
-            batch_id_counter += 1
-
-            # Store batch-level information for event grouping
-            batch_tracker[batch_id] = {
-                'detector_images_4d': detector_images_4d,  # (B, C, H, W)
-                'B': B,
-                'C': C,
-                'H_orig': H_orig,
-                'W_orig': W_orig,
-                'photon_energy': photon_energy,
-                'photon_wavelength': photon_wavelength,
-                'timestamp': timestamp,
-                'metadata': metadata,
-                'num_panels': batch_size,
-                'completed_panels': [],  # Will collect (panel_idx, peaks, image)
-            }
-
-            # Split batch into mini-batches for parallel processing
-            samples_per_task = max(1, batch_size // num_cpu_workers)
-
-            # Launch parallel tasks
-            for i in range(0, batch_size, samples_per_task):
-                mini_batch_logits = logits[i:i+samples_per_task]
-
-                # RAY BEST PRACTICE: Use ray.put() for large objects
-                mini_batch_logits_ref = ray.put(mini_batch_logits)  # Zero-copy via object store
-
-                # Launch task
-                task_ref = process_samples_task.remote(mini_batch_logits_ref, structure_ref)
-
-                pending_tasks.append({
-                    'task_ref': task_ref,
-                    'batch_id': batch_id,
-                    'panel_start_idx': i,  # Starting panel index in this mini-batch
-                    'panel_count': min(samples_per_task, batch_size - i)
-                })
-
-            batches_processed += 1
-
-            # Get next batch for next iteration
-            current_batch = q2_manager.get(timeout=0.01)
-
-            # Non-blocking check for completed tasks
-            if pending_tasks:
-                ready_refs = [t['task_ref'] for t in pending_tasks]
-                ready, not_ready_refs = ray.wait(
-                    ready_refs,
-                    num_returns=min(10, len(ready_refs)),  # Optimized num_returns
-                    timeout=0  # Non-blocking
-                )
-
-                if ready:
-                    # RAY BEST PRACTICE: Batch ray.get()
-                    ready_peaks = ray.get(ready)
-                    ready_task_map = {ref: peaks for ref, peaks in zip(ready, ready_peaks)}
-
-                    # Collect completed panel results
-                    completed_batches = set()
-                    for task_ref in ready:
-                        task_data = next(t for t in pending_tasks if t['task_ref'] == task_ref)
-                        batch_id = task_data['batch_id']
-                        panel_start_idx = task_data['panel_start_idx']
-                        panel_count = task_data['panel_count']
-                        peaks_list = ready_task_map[task_ref]
-
-                        # Store peaks for each panel in this mini-batch
-                        batch_info = batch_tracker[batch_id]
-                        for i in range(panel_count):
-                            panel_idx = panel_start_idx + i
-                            panel_peaks = peaks_list[i] if i < len(peaks_list) else []
-                            batch_info['completed_panels'].append((panel_idx, panel_peaks, None))
-
-                        # Check if this batch is complete
-                        if len(batch_info['completed_panels']) >= batch_info['num_panels']:
-                            completed_batches.add(batch_id)
-
-                    # Remove completed tasks from pending
-                    pending_tasks = [t for t in pending_tasks if t['task_ref'] not in ready]
-
-                    # Submit completed batches
-                    for batch_id in completed_batches:
-                        batch_info = batch_tracker[batch_id]
-
-                        # Group panels into events
-                        event_images, event_peaks, event_metadata = group_panels_into_events(batch_info)
-
-                        # Submit to file writer
-                        file_writer.submit_processed_batch.remote(
-                            event_images,
-                            event_peaks,
-                            event_metadata
-                        )
-
-                        # Clean up
-                        del batch_tracker[batch_id]
+            # Periodic flush: write CXI file every N batches
+            if batches_since_flush >= batches_per_file:
+                logger.info(f"=== Writing CXI file after {batches_since_flush} batches ===")
+                stats = ray.get(file_writer.flush_final.remote())
+                logger.info(f"Wrote CXI: {stats['chunks_written']} files, "
+                           f"{stats['total_events_written']} events written, "
+                           f"{stats['total_events_filtered']} events filtered")
+                batches_since_flush = 0
 
             # Progress logging
-            if batches_processed % 50 == 0:
-                elapsed = time.time() - start_time
-                rate = batches_processed / elapsed if elapsed > 0 else 0
-                logging.info(
-                    f"Processed {batches_processed} batches, "
-                    f"{rate:.1f} batches/s, "
-                    f"{len(pending_tasks)} pending tasks"
-                )
+            if batch_count % 50 == 0:
+                logger.info(f"Progress: {batch_count} batches, {total_events} events")
 
     except KeyboardInterrupt:
-        logging.info("Received interrupt signal - shutting down...")
-
+        logger.info("\n=== Interrupted by user ===")
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        import traceback
+        logger.error(traceback.format_exc())
     finally:
-        # Wait for remaining tasks
-        if pending_tasks:
-            logging.info(f"Waiting for {len(pending_tasks)} pending tasks...")
-            ready_refs = [t['task_ref'] for t in pending_tasks]
-
-            # RAY BEST PRACTICE: Batch ray.get()
-            all_peaks = ray.get(ready_refs)
-            peaks_map = {ref: peaks for ref, peaks in zip(ready_refs, all_peaks)}
-
-            # Collect remaining panel results
-            for task_data in pending_tasks:
-                batch_id = task_data['batch_id']
-                panel_start_idx = task_data['panel_start_idx']
-                panel_count = task_data['panel_count']
-                peaks_list = peaks_map[task_data['task_ref']]
-
-                batch_info = batch_tracker[batch_id]
-                for i in range(panel_count):
-                    panel_idx = panel_start_idx + i
-                    panel_peaks = peaks_list[i] if i < len(peaks_list) else []
-                    batch_info['completed_panels'].append((panel_idx, panel_peaks, None))
-
-            # Submit all remaining batches
-            for batch_id in list(batch_tracker.keys()):
-                batch_info = batch_tracker[batch_id]
-                event_images, event_peaks, event_metadata = group_panels_into_events(batch_info)
-                file_writer.submit_processed_batch.remote(event_images, event_peaks, event_metadata)
-                del batch_tracker[batch_id]
-
         # Final flush
-        logging.info("Flushing final CXI file...")
+        logger.info("Flushing final CXI file...")
         stats = ray.get(file_writer.flush_final.remote())
 
-        total_time = time.time() - start_time
-
-        logging.info("=== CPU Post-Processing Pipeline Completed ===")
-        logging.info(f"Total batches: {batches_processed}")
-        logging.info(f"Total events written: {stats['total_events_written']}")
-        logging.info(f"Total events filtered: {stats['total_events_filtered']}")
-        logging.info(f"CXI chunks: {stats['chunks_written']}")
-        logging.info(f"Total time: {total_time:.2f}s")
-        logging.info(f"Throughput: {batches_processed/total_time:.1f} batches/s")
+        logger.info("\n=== Processing Complete ===")
+        logger.info(f"Total batches: {batch_count}")
+        logger.info(f"Total events: {total_events}")
+        logger.info(f"Events written: {stats['total_events_written']}")
+        logger.info(f"Events filtered: {stats['total_events_filtered']}")
+        logger.info(f"CXI files: {stats['chunks_written']}")

--- a/cxi_pipeline_ray/core/peak_finding.py
+++ b/cxi_pipeline_ray/core/peak_finding.py
@@ -1,83 +1,54 @@
 """
-Peak finding Ray task for CPU-based post-processing.
+Peak finding using scipy.ndimage for CXI post-processing.
 
-This module provides a stateless Ray task that performs peak finding on
-segmentation maps using scipy.ndimage.
+This module provides a plain function (no Ray, no torch) that performs peak finding
+on segmentation logits using connected component labeling and center of mass.
 """
 
-import ray
 import numpy as np
 from scipy import ndimage
-import torch
 
 
-@ray.remote
-def process_samples_task(samples, structure):
+def find_peaks_numpy(logits_2d: np.ndarray, return_seg_map: bool = False):
     """
-    Stateless Ray task for peak finding using scipy.ndimage.
-
-    This task processes a mini-batch of samples, converting logits to segmentation
-    maps and finding peaks using connected component labeling and center of mass
-    calculation.
+    Find peaks from 2-class logits using scipy.ndimage.label.
 
     Args:
-        samples: Mini-batch of sample logits with shape (N, num_classes, H, W).
-                 Note: ObjectRefs are automatically dereferenced by Ray when passed
-                 as top-level arguments to remote functions.
-        structure: Shared 8-connectivity structure for ndimage.label (3x3 array).
-                   Auto-dereferenced from ObjectRef by Ray.
+        logits_2d: (2, H, W) logits from model
+        return_seg_map: If True, return (peaks, seg_map) tuple
 
     Returns:
-        List of peak positions per sample: [[[idx, y, x], ...], ...]
-        where idx is the sample index (local to this mini-batch).
-
-        NOTE: Event/panel grouping is done in coordinator.py using global indices,
-        not here with local mini-batch indices.
-
-    Note:
-        - Ray automatically dereferences ObjectRefs at function boundaries
-        - Performs softmax + argmax to convert logits to binary segmentation
-        - Uses scipy.ndimage.label for connected component labeling
-        - Uses scipy.ndimage.center_of_mass for peak localization
-        - Matches OLD_CXI_DEV_DIR peak finding algorithm
+        peaks: (N, 3) array of [panel_idx=0, y, x]
+        OR
+        (peaks, seg_map): If return_seg_map=True, where seg_map is (H, W) uint8 with values 0 or 1
     """
-    all_peaks = []
+    # Binary segmentation via argmax (class 0=background, class 1=peak)
+    seg_map = np.argmax(logits_2d, axis=0)  # (H, W) with values 0 or 1
 
-    for sample_idx, sample_logits in enumerate(samples):
-        # Stage 1: Logits → Segmentation Map
-        # Input: (num_classes=2, H, W) - class 0=background, class 1=peak
-        # Output: (H, W) binary mask
-        if isinstance(sample_logits, torch.Tensor):
-            seg_map = sample_logits.softmax(dim=0).argmax(dim=0).cpu().numpy()
-        else:
-            # Already numpy array
-            seg_map = sample_logits.argmax(axis=0)
+    peak_mask = (seg_map == 1)
 
-        # Stage 2: Connected Component Labeling
-        # Find distinct peak regions using 8-connectivity
-        labeled_map, num_peaks = ndimage.label(seg_map, structure)
+    # Find connected components (8-connectivity)
+    structure = np.ones((3, 3), dtype=np.float32)
+    labeled, num_features = ndimage.label(peak_mask, structure=structure)
 
-        # Stage 3: Center of Mass for each peak
-        if num_peaks > 0:
-            peak_coords = ndimage.center_of_mass(
-                seg_map.astype(np.float32),
-                labeled_map.astype(np.float32),
-                np.arange(1, num_peaks + 1)
-            )
+    if num_features == 0:
+        peaks = np.array([]).reshape(0, 3)
+    else:
+        # Find center of mass for each component
+        peaks = []
+        for label_id in range(1, num_features + 1):
+            component_mask = labeled == label_id
+            y_coords, x_coords = np.where(component_mask)
 
-            # Convert to [sample_idx, y, x] format
-            # sample_idx is local to this mini-batch - coordinator will handle global grouping
-            peaks = []
-            for coords in peak_coords:
-                if isinstance(coords, tuple) and len(coords) == 2:
-                    y, x = coords
-                    peaks.append([sample_idx, float(y), float(x)])
-                elif isinstance(coords, (list, np.ndarray)) and len(coords) == 2:
-                    y, x = coords
-                    peaks.append([sample_idx, float(y), float(x)])
-        else:
-            peaks = []
+            # Center of mass
+            y_center = y_coords.mean()
+            x_center = x_coords.mean()
 
-        all_peaks.append(peaks)
+            peaks.append([0, y_center, x_center])  # panel_idx=0 for single panel
 
-    return all_peaks
+        peaks = np.array(peaks, dtype=np.float32)
+
+    if return_seg_map:
+        return peaks, seg_map.astype(np.uint8)
+    else:
+        return peaks

--- a/cxi_pipeline_ray/core/reconstruction.py
+++ b/cxi_pipeline_ray/core/reconstruction.py
@@ -5,9 +5,38 @@ This module provides utilities to reconstruct detector images from preprocessed
 format back to original size, and convert physics metadata to CXI-compatible formats.
 """
 
+import logging
 import numpy as np
 import ray
 from typing import Union
+
+
+def reconstruct_from_arrays(original_image: np.ndarray, original_shape: tuple, preprocessed_shape: tuple) -> np.ndarray:
+    """
+    Reconstruct detector image from preprocessed format.
+
+    Args:
+        original_image: (B*C, 1, H, W) preprocessed image
+        original_shape: (B, C, H_orig, W_orig)
+        preprocessed_shape: (B*C, 1, H, W)
+
+    Returns:
+        detector_image: (B, C, H_orig, W_orig) in original coordinates
+    """
+    B, C, H_orig, W_orig = original_shape
+    BC, _, H, W = preprocessed_shape
+
+    if original_image.shape != (BC, 1, H, W):
+        raise ValueError(f"Image shape {original_image.shape} doesn't match preprocessed_shape {preprocessed_shape}")
+
+    # Reshape: (B*C, 1, H, W) → (B, C, H, W)
+    image_reshaped = original_image.reshape(B, C, H, W)
+
+    # Unpad: (B, C, H, W) → (B, C, H_orig, W_orig)
+    # Bottom-right padding means original data is at [0:H_orig, 0:W_orig]
+    image_original = image_reshaped[:, :, :H_orig, :W_orig]
+
+    return image_original
 
 
 def reconstruct_detector_image(output) -> np.ndarray:
@@ -23,18 +52,10 @@ def reconstruct_detector_image(output) -> np.ndarray:
 
     Returns:
         detector_image: (B, C, H_orig, W_orig) numpy array in original coordinates
-
-    Raises:
-        ValueError: If preprocessing_metadata is missing or invalid
-
-    Example:
-        >>> output = q2_manager.get()
-        >>> detector_image = reconstruct_detector_image(output)
-        >>> assert detector_image.shape == (8, 16, 352, 384)  # B=8, C=16 panels
     """
     # Check if preprocessing metadata is available
     if output.preprocessing_metadata is None:
-        # No preprocessing was applied - return image as-is
+        logging.warning("preprocessing_metadata is None — returning image as-is")
         if output.original_image_ref is None:
             raise ValueError("Both preprocessing_metadata and original_image_ref are None")
         return ray.get(output.original_image_ref)
@@ -45,25 +66,11 @@ def reconstruct_detector_image(output) -> np.ndarray:
 
     detector_image = ray.get(output.original_image_ref)  # (B*C, 1, H, W)
 
-    # Extract shape information from metadata
-    B, C, H_orig, W_orig = output.preprocessing_metadata.original_shape
-    BC, _, H, W = output.preprocessing_metadata.preprocessed_shape
-
-    # Validate shapes
-    if detector_image.shape != (BC, 1, H, W):
-        raise ValueError(
-            f"Image shape {detector_image.shape} doesn't match "
-            f"preprocessed_shape {(BC, 1, H, W)} from metadata"
-        )
-
-    # Step 1: Reshape (B*C, 1, H, W) → (B, C, H, W)
-    detector_image_reshaped = detector_image.reshape(B, C, H, W)
-
-    # Step 2: Unpad (B, C, H, W) → (B, C, H_orig, W_orig)
-    # Bottom-right padding means original data is at [0:H_orig, 0:W_orig]
-    detector_image_original = detector_image_reshaped[:, :, :H_orig, :W_orig]
-
-    return detector_image_original
+    return reconstruct_from_arrays(
+        detector_image,
+        output.preprocessing_metadata.original_shape,
+        output.preprocessing_metadata.preprocessed_shape,
+    )
 
 
 def wavelength_to_energy(wavelength: Union[float, np.ndarray], unit: str = 'angstrom') -> Union[float, np.ndarray]:

--- a/cxi_pipeline_ray/utils/config.py
+++ b/cxi_pipeline_ray/utils/config.py
@@ -60,15 +60,6 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if 'poll_timeout' not in config['queue']:
         config['queue']['poll_timeout'] = 0.01
 
-    if 'processing' not in config:
-        config['processing'] = {}
-
-    if 'num_cpu_workers' not in config['processing']:
-        config['processing']['num_cpu_workers'] = 16
-
-    if 'max_pending_tasks' not in config['processing']:
-        config['processing']['max_pending_tasks'] = 100
-
     if 'peak_finding' not in config:
         config['peak_finding'] = {}
 
@@ -87,6 +78,9 @@ def load_config(config_path: str) -> Dict[str, Any]:
     if 'create_output_dir' not in config['output']:
         config['output']['create_output_dir'] = True
 
+    if 'batches_per_file' not in config['output']:
+        config['output']['batches_per_file'] = 10
+
     return config
 
 
@@ -101,14 +95,13 @@ def merge_config_with_overrides(config: Dict[str, Any], cli_args) -> Dict[str, A
     Returns:
         Updated configuration dictionary
     """
-    # Override processing settings if provided
-    if hasattr(cli_args, 'num_cpu_workers') and cli_args.num_cpu_workers is not None:
-        config['processing']['num_cpu_workers'] = cli_args.num_cpu_workers
-
-    if hasattr(cli_args, 'max_pending_tasks') and cli_args.max_pending_tasks is not None:
-        config['processing']['max_pending_tasks'] = cli_args.max_pending_tasks
-
     # Override output settings if provided
+    if hasattr(cli_args, 'batches_per_file') and cli_args.batches_per_file is not None:
+        config['output']['batches_per_file'] = cli_args.batches_per_file
+
+    if hasattr(cli_args, 'save_segmentation_maps') and cli_args.save_segmentation_maps:
+        config['output']['save_segmentation_maps'] = True
+
     if hasattr(cli_args, 'output_dir') and cli_args.output_dir is not None:
         config['output']['output_dir'] = cli_args.output_dir
 

--- a/cxi_pipeline_ray/version.py
+++ b/cxi_pipeline_ray/version.py
@@ -1,3 +1,3 @@
 """Version information for cxi-pipeline-ray package."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cxi-pipeline-ray"
-version = "0.1.0"
+version = "0.2.0"
 description = "Ray-based CPU post-processing pipeline for PeakNet inference results"
 authors = [
     {name = "Chun Hong Yoon", email = "cxyoon@slac.stanford.edu"},
@@ -14,7 +14,6 @@ dependencies = [
     "numpy>=1.20.0",
     "scipy>=1.7.0",
     "h5py>=3.0.0",
-    "torch>=2.0.0",
     "pyyaml>=6.0",
 ]
 


### PR DESCRIPTION
## Summary

- Replaced async Ray task coordinator (370 lines) with synchronous `run_sync_pipeline()`
- Inline `find_peaks_numpy()` — argmax + scipy.ndimage.label (no Ray remote tasks)
- Added `reconstruct_from_arrays()` for array-based image reconstruction
- Fixed metadata crash resilience (warn + continue instead of ValueError)
- Added `--batches-per-file` and `--save-segmentation-maps` CLI flags
- Removed `torch` from package dependencies
- Bumped version to 0.2.0

Closes #4

## Test plan

- [x] Offline: peak finding + reconstruction equivalence verified (deterministic tests)
- [x] Full pipeline test: job 23029974, 60+ batches, 9 CXI files, 249 events written
- [x] `cxi-writer --config cxi_writer.yaml --batches-per-file 10` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)